### PR TITLE
Add auto-allow for read-only tools

### DIFF
--- a/vault-template/.claude/settings.json
+++ b/vault-template/.claude/settings.json
@@ -58,6 +58,17 @@
         ]
       }
     ],
+    "PermissionRequest": [
+      {
+        "matcher": "Read|Glob|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '{\"hookSpecificOutput\": {\"hookEventName\": \"PermissionRequest\", \"decision\": {\"behavior\": \"allow\"}}}'"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",


### PR DESCRIPTION
## Summary

- Adds a `PermissionRequest` hook that auto-approves `Read`, `Glob`, and `Grep` operations
- These tools only read files and cannot modify the vault, so prompting for each adds friction without safety benefit
- Eliminates the most frequent permission prompts during normal usage (searching, reading notes, exploring)

### How it works

The hook matches `Read|Glob|Grep` and returns a JSON decision with `behavior: "allow"`. No external script needed — it's an inline `echo` command in `settings.json`.

### Files changed

- `vault-template/.claude/settings.json` — added `PermissionRequest` hook section

### Why this matters

New users are often frustrated by constant permission prompts when Claude is just reading their notes. This is the single biggest UX improvement for reducing prompt fatigue.
