### PR TITLE
Add bash safety hook to block destructive commands

### DIFF
--- a/vault-template/.claude/hooks/bash-safety.sh
+++ b/vault-template/.claude/hooks/bash-safety.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Bash safety hook (PermissionRequest: Bash)
+# Blocks destructive commands that could damage the vault or git history
+# BLOCKING — prevents execution of dangerous commands
+
+# Read hook JSON from stdin
+INPUT=$(cat)
+
+# Extract the command (jq preferred, fallback to grep)
+if command -v jq >/dev/null 2>&1; then
+    COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+else
+    COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//;s/"$//')
+fi
+[ -z "$COMMAND" ] && exit 0
+
+# Check for destructive patterns
+REASON=""
+
+# Recursive delete
+if echo "$COMMAND" | grep -qE 'rm\s+.*-[a-zA-Z]*[rR]'; then
+    REASON="Recursive rm detected"
+fi
+
+# Force push
+if echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force|git\s+push\s+-f'; then
+    REASON="Force push detected"
+fi
+
+# Hard reset
+if echo "$COMMAND" | grep -qE 'git\s+reset\s+--hard'; then
+    REASON="Hard reset detected"
+fi
+
+# Clean untracked files
+if echo "$COMMAND" | grep -qE 'git\s+clean\s+.*-f'; then
+    REASON="git clean -f detected"
+fi
+
+# Discard all changes
+if echo "$COMMAND" | grep -qE 'git\s+checkout\s+\.'; then
+    REASON="git checkout . (discard all changes) detected"
+fi
+
+# If dangerous command found, block it
+if [ -n "$REASON" ]; then
+    echo "{\"hookSpecificOutput\": {\"hookEventName\": \"PermissionRequest\", \"decision\": {\"behavior\": \"block\", \"reason\": \"$REASON. This command could cause data loss. Use with caution.\"}}}"
+fi
+
+exit 0

--- a/vault-template/.claude/settings.json
+++ b/vault-template/.claude/settings.json
@@ -58,6 +58,18 @@
         ]
       }
     ],
+    "PermissionRequest": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/bash-safety.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",


### PR DESCRIPTION
## Summary

- Adds a `PermissionRequest` hook on `Bash` that blocks destructive commands before they execute
- Shell-only implementation with optional `jq` for JSON parsing (falls back to grep)

### What it blocks

| Command pattern | Why |
|----------------|-----|
| `rm -r`, `rm -rf` | Recursive delete could destroy vault content |
| `git push --force` | Can overwrite remote history |
| `git reset --hard` | Discards uncommitted changes |
| `git clean -f` | Removes untracked files permanently |
| `git checkout .` | Discards all working directory changes |

Non-destructive commands (including safe `rm` of single files) pass through to the normal permission prompt.

### Files changed

- `vault-template/.claude/hooks/bash-safety.sh` — new hook (shell, no dependencies)
- `vault-template/.claude/settings.json` — registered as `PermissionRequest` hook on `Bash`

### Design decisions

- **PermissionRequest hook** (not PreToolUse) — this is the correct event for gating tool execution
- **Block, don't deny** — user can still override if they know what they're doing
- **Shell-only** — matches existing hook conventions, jq used only if available
