### PR TITLE
Add macOS notification hooks for idle and completion

### DIFF
--- a/vault-template/.claude/settings.json
+++ b/vault-template/.claude/settings.json
@@ -58,6 +58,26 @@
         ]
       }
     ],
+    "Notification": [
+      {
+        "matcher": "idle_prompt|permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "osascript -e 'display notification \"Claude is waiting for input\" with title \"Claude Code\" sound name \"Glass\"' 2>/dev/null; exit 0"
+          }
+        ]
+      },
+      {
+        "matcher": "Stop",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "osascript -e 'display notification \"Claude has finished\" with title \"Claude Code\" sound name \"Glass\"' 2>/dev/null; exit 0"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",


### PR DESCRIPTION
## Summary

- Adds `Notification` hooks that alert the user via native macOS notifications
- Triggers on `idle_prompt|permission_prompt` (Claude is waiting) and `Stop` (Claude finished)
- Uses `osascript` with silent fallback (`2>/dev/null; exit 0`) — does nothing on Linux

### What you get

- **Waiting notification** — plays a sound and shows "Claude is waiting for input" when Claude needs a decision or is idle
- **Completion notification** — plays a sound and shows "Claude has finished" when a task completes

### Files changed

- `vault-template/.claude/settings.json` — added `Notification` hook section

### Design decisions

- **Inline osascript** — no external script needed, keeps it simple
- **Silent failure** — `2>/dev/null; exit 0` means it does nothing on Linux/WSL instead of erroring
- **Glass sound** — macOS built-in, non-intrusive

### Why this matters

Long-running operations (vault reorganisation, weekly reviews, multi-file edits) can take minutes. Without notifications, users have to watch the terminal. This lets them switch to another window and get called back when needed.

🤖 Generated with [Claude Code](https://claude.ai/code)